### PR TITLE
Update PingOne Protect Initialize Node link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > Please refer to the following documentation for up-to-date information on these nodes and associated services:
 > - [Getting Started with PingOne Protect](https://docs.pingidentity.com/pingone/threat_protection_using_pingone_protect/p1_protect_getting_started.html)
-> - [PingOne Protect Initialize Node](https://docs.pingidentity.com/bundle/pingone-protect/page/p1p-init-node.html)
+> - [PingOne Protect Initialize Node](https://docs.pingidentity.com/auth-node-ref/latest/pingone/pingone-protect-initialize.html)
 > - [PingOne Protect Evaluation Node](https://docs.pingidentity.com/auth-node-ref/latest/pingone/pingone-protect-evaluation.html)
 > - [PingOne Protect Result Node](https://docs.pingidentity.com/auth-node-ref/latest/pingone/pingone-protect-result.html)
 >


### PR DESCRIPTION
This is a correction in response to a feedback request DF-1409 we received in the Ping Identity Documentation team. Please update and publish the new version.

Review any other links that might also be outdated in different repos.